### PR TITLE
增加命令图标

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,7 @@ export default class PublishToDiscourse extends Plugin implements PluginInterfac
 		this.addCommand({
 			id: "publish-to-discourse",
 			name: t('PUBLISH_TO_DISCOURSE'),
+			icon: 'newspaper',
 			callback: () => {
 				this.publishToDiscourse();
 			},
@@ -57,6 +58,7 @@ export default class PublishToDiscourse extends Plugin implements PluginInterfac
 		this.addCommand({
 			id: "open-in-discourse",
 			name: t('OPEN_IN_DISCOURSE'),
+			icon: 'globe',
 			callback: () => {
 				this.openInDiscourse();
 			},
@@ -75,6 +77,7 @@ export default class PublishToDiscourse extends Plugin implements PluginInterfac
 	registerDirMenu(menu: Menu, file: TFile) {
 		const syncDiscourse = (item: MenuItem) => {
 			item.setTitle(t('PUBLISH_TO_DISCOURSE'));
+			item.setIcon('newspaper');
 			item.onClick(async () => {
 				await this.publishToDiscourse(file);
 			});


### PR DESCRIPTION
增加菜单命令图标，和菜单中其他项目匹配：
<img width="268" height="295" alt="Snipaste_2025-07-22_20-34-20" src="https://github.com/user-attachments/assets/ce3458b7-95f8-464f-a3c1-5b07df3109ed" />

另外，给命令本身也增加图标，用于侧栏（功能区）和移动端添加命令：
<img width="741" height="275" alt="Snipaste_2025-07-22_20-35-03" src="https://github.com/user-attachments/assets/15e0a533-cf32-46a1-aff6-3cf514e06c0d" />
