### PR TITLE
feat: 文件链接处理改进；支持忽略标题层级的识别

### DIFF
--- a/src/embed-handler.ts
+++ b/src/embed-handler.ts
@@ -37,11 +37,16 @@ export class EmbedHandler {
     async processEmbeds(embedReferences: string[], activeFileName: string, useRemoteUrl = false): Promise<string[]> {
         const uploadedUrls: string[] = [];
         for (const ref of embedReferences) {
-            // 处理带有#的文件路径，分离文件名和标题部分
+            // 处理带有 # 和 | 的文件路径，分离文件名和标题部分
             let filePart = ref;
             const hashIndex = filePart.indexOf("#");
             if (hashIndex >= 0) {
                 filePart = filePart.substring(0, hashIndex).trim();
+            }
+            
+            const pipeIndex = filePart.indexOf("|");
+            if (pipeIndex >= 0) {
+                filePart = filePart.substring(0, pipeIndex).trim();
             }
             
             const filePath = this.app.metadataCache.getFirstLinkpathDest(filePart, activeFileName)?.path;


### PR DESCRIPTION
- 改进链接处理，兼容 | 的别名（也包括图片文件的 ![[image|300]] 这种情况）
- 改进标题替换算法，支持识别标题层级
- 把 H1 替换的顺序后置，避免和“忽略标题”冲突